### PR TITLE
add keywords "pma" and "mailhog" to launch command

### DIFF
--- a/cmd/ddev/cmd/dotddev_assets/commands/host/launch
+++ b/cmd/ddev/cmd/dotddev_assets/commands/host/launch
@@ -2,18 +2,28 @@
 
 ## #ddev-generated
 ## Description: Launch a browser with the current site
-## Usage: launch [path]
-## Example: "ddev launch" or "ddev launch /admin/reports/status/php" or "ddev launch phpinfo.php"
+## Usage: launch [path|pma|mailhog]
+## Example: "ddev launch" or "ddev launch /admin/reports/status/php" or "ddev launch phpinfo.php" or "ddev launch pma" or "ddev launch mailhog"
 
-FULLURL=${DDEV_PRIMARY_URL}
-
-if [ -n "${1:-}" ] ; then 
-  if [[ ${1::1} != "/" ]] ; then 
-    FULLURL="${FULLURL}/"; 
-  fi
-
-  FULLURL="${FULLURL}${1}"; 
-fi
+case "${1}" in
+  mailhog)
+    # build the MailHog URL
+    FULLURL="http://${DDEV_HOSTNAME}:${DDEV_MAILHOG_PORT}"
+    ;;
+  pma)
+    # build the PhpMyAdmin URL
+    FULLURL="http://${DDEV_HOSTNAME}:${DDEV_PHPMYADMIN_PORT}"
+    ;;
+  *)
+    FULLURL=${DDEV_PRIMARY_URL}
+    if [ -n "${1:-}" ]; then
+      if [[ ${1::1} != "/" ]]; then
+        FULLURL="${FULLURL}/"
+      fi
+    fi
+    FULLURL="${FULLURL}${1}"
+    ;;
+esac
 
 case $OSTYPE in
   linux-gnu)


### PR DESCRIPTION
this allows the ddev launch command to launch PHPMyAdmin and and Mailhog

## The Problem/Issue/Bug:

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

